### PR TITLE
:sparkles: Make deletion protection default configurable

### DIFF
--- a/api/config/v2alpha1/projectconfig_types.go
+++ b/api/config/v2alpha1/projectconfig_types.go
@@ -37,6 +37,10 @@ type ProjectConfig struct {
 	// running multiple controllers in the same cluster.
 	ControllerClass string `json:"controllerClass"`
 
+	// DeletionProtectionDefault sets the default to use with regards to deletion
+	// protection if it is not set on the resource.
+	DeletionProtectionDefault bool `json:"deletionProtectionDefault"`
+
 	// DisableCRDWebhooks disables the CRD webhooks on the controller. If running
 	// multiple controllers in the same cluster, only one will need to have it's
 	// webhooks enabled.

--- a/api/styra/v1alpha1/globaldatasource_webhook.go
+++ b/api/styra/v1alpha1/globaldatasource_webhook.go
@@ -45,9 +45,6 @@ var _ webhook.Defaulter = &GlobalDatasource{}
 func (r *GlobalDatasource) Default() {
 	globalDatasourceWebhookLog.Info("default", "name", r.Name)
 
-	if r.Spec.DeletionProtection == nil {
-		r.Spec.DeletionProtection = ptr.Bool(true)
-	}
 	if r.Spec.Enabled == nil {
 		r.Spec.Enabled = ptr.Bool(true)
 	}

--- a/api/styra/v1beta1/system_webhook.go
+++ b/api/styra/v1beta1/system_webhook.go
@@ -26,8 +26,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-
-	"github.com/bankdata/styra-controller/pkg/ptr"
 )
 
 // log is for logging in this package.
@@ -53,10 +51,6 @@ func (s *System) Default() {
 		if s.Spec.SourceControl.Origin.Reference == "" && s.Spec.SourceControl.Origin.Commit == "" {
 			s.Spec.SourceControl.Origin.Reference = "refs/heads/master"
 		}
-	}
-
-	if s.Spec.DeletionProtection == nil {
-		s.Spec.DeletionProtection = ptr.Bool(true)
 	}
 }
 

--- a/config/crd/bases/styra.bankdata.dk_globaldatasources.yaml
+++ b/config/crd/bases/styra.bankdata.dk_globaldatasources.yaml
@@ -74,8 +74,8 @@ spec:
                   be enabled.
                 type: boolean
               name:
-                description: Name is the name the datasource has in the Styra DAS
-                  GUI
+                description: Name is the name to use for the global datasource in
+                  Styra DAS
                 type: string
               path:
                 description: Path is the path in git in git/xx datasources.

--- a/config/samples/config_v2alpha1_projectconfig.yaml
+++ b/config/samples/config_v2alpha1_projectconfig.yaml
@@ -6,6 +6,10 @@ kind: ProjectConfig
 # multiple controllers in the same cluster.
 controllerClass: ""
 
+# deletionProtectionDefault sets the default to use with regards to deletion
+# protection if it is not set on the resource.
+deletionProtectionDefault: false
+
 # disableCRDWebhooks disables the CRD webhooks on the controller. If running
 # multiple controllers in the same cluster, only one will need to have it's
 # webhooks enabled.

--- a/test/integration/webhook/globaldatasource_webhook_test.go
+++ b/test/integration/webhook/globaldatasource_webhook_test.go
@@ -43,15 +43,6 @@ func newGlobalDatasource() *v1alpha1.GlobalDatasource {
 var _ = Describe("GlobalDatasource", Label("integration"), func() {
 
 	Describe("Default", Label("integration"), func() {
-		It("should set deletionProtection", func() {
-			gds := newGlobalDatasource()
-			ctx := context.Background()
-			Ω(k8sClient.Create(ctx, gds)).To(Succeed())
-			Ω(gds.Spec.DeletionProtection).NotTo(BeNil())
-			Ω(*gds.Spec.DeletionProtection).To(BeTrue())
-			Ω(k8sClient.Delete(ctx, gds)).To(Succeed())
-		})
-
 		It("should set the enabled true", func() {
 			gds := newGlobalDatasource()
 			ctx := context.Background()


### PR DESCRIPTION
This adds a new configuration option which sets the default to use for
deletion protection if it is unset on the resource. You might want to
have deletion protection on by default in production environments and
off in development environments.

fixes #29 
