### PR TITLE
:sparkles: Create a new system on 404

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -68,6 +68,11 @@ func (err *ReconcilerErr) Cause() error {
 	return err.err
 }
 
+// Unwrap is the same as `Cause()`
+func (err *ReconcilerErr) Unwrap() error {
+	return err.Cause()
+}
+
 // StackTrace implements the stackTracer interface.
 func (err *ReconcilerErr) StackTrace() errors.StackTrace {
 	var st stackTracer


### PR DESCRIPTION
If a system has been deleted in Styra by other means than the controller, it will get stuck on reconciling the system as gets for the system id will return 404. With this change, the controller will automatically create a new system, if the system doesn't exist in styra anymore.