### PR TITLE
:sparkles: Allow setting description on datasources

### DIFF
--- a/api/styra/v1beta1/system_types.go
+++ b/api/styra/v1beta1/system_types.go
@@ -223,6 +223,9 @@ type GitRepo struct {
 type Datasource struct {
 	// Path is the path within the system where the datasource should reside.
 	Path string `json:"path"`
+
+	// Description is a description of the datasource
+	Description string `json:"description,omitempty"`
 }
 
 // SystemStatus defines the observed state of System.

--- a/config/crd/bases/styra.bankdata.dk_systems.yaml
+++ b/config/crd/bases/styra.bankdata.dk_systems.yaml
@@ -51,6 +51,9 @@ spec:
                   description: Datasource represents a Styra datasource to be mounted
                     in the system.
                   properties:
+                    description:
+                      description: Description is a description of the datasource
+                      type: string
                     path:
                       description: Path is the path within the system where the datasource
                         should reside.

--- a/docs/apis/styra/v1beta1.md
+++ b/docs/apis/styra/v1beta1.md
@@ -253,6 +253,17 @@ string
 <p>Path is the path within the system where the datasource should reside.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>description</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<p>Description is a description of the datasource</p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="styra.bankdata.dk/v1beta1.DecisionMapping">DecisionMapping
@@ -1161,5 +1172,5 @@ System.</p>
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>534b87f</code>.
+on git commit <code>d2179ec</code>.
 </em></p>

--- a/internal/controller/styra/system_controller.go
+++ b/internal/controller/styra/system_controller.go
@@ -699,11 +699,12 @@ func (r *SystemReconciler) reconcileDatasources(
 		id := path.Join("systems", system.Status.ID, ssds.Path)
 		expectedByID[id] = ssds
 		ds, ok := existingByID[id]
-		if !ok || ds.Category != "rest" {
+		if !ok || ds.Category != "rest" || ds.Description != ssds.Description {
 			log := log.WithValues("datasourceID", id)
 			log.Info("Creating or updating datasource")
 			_, err := r.Styra.UpsertDatasource(ctx, id, &styra.UpsertDatasourceRequest{
-				Category: "rest",
+				Category:    "rest",
+				Description: ssds.Description,
 			})
 			if err != nil {
 				return ctrl.Result{}, ctrlerr.Wrap(err, "Could not create or update datasource").


### PR DESCRIPTION
This adds a new field `description` to the datasources which allows
setting the description of a datasource.
